### PR TITLE
Match colorize output with Morgan

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
       meta: true, // optional: control whether you want to log the meta data about the request (default to true)
       msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
       expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
-      colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+      colorize: false, // Color the status code, using the Express/morgan color palette (2XX green, 3XX cyan, 4XX yellow, 5XX red).
       ignoreRoute: function (req, res) { return false; } // optional: allows to skip some log messages based on request and/or response
     }));
 
@@ -67,7 +67,7 @@ Use `expressWinston.logger(options)` to create a middleware to log your HTTP req
     level: String or function(req, res) { return String; }, // log level to use, the default is "info". Assign a  function to dynamically set the level based on request and response, or a string to statically set it always at that level. statusLevels must be false for this setting to be used.
     msg: String // customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}", "HTTP {{req.method}} {{req.url}}".
     expressFormat: Boolean, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors when colorize set to true
-    colorize: Boolean, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+    colorize: Boolean, // Color the status code, using the Express/morgan color palette (2XX green, 3XX cyan, 4XX yellow, 5XX red).
     meta: Boolean, // control whether you want to log the meta data about the request (default to true).
     baseMeta: Object, // default meta data to be added to log, this will be merged with the meta data.
     metaField: String, // if defined, the meta data will be added in this field instead of the meta root object.

--- a/index.js
+++ b/index.js
@@ -293,15 +293,15 @@ exports.logger = function logger(options) {
 
             var expressMsgFormat = "{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms";
             if (options.colorize) {
-              // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L205
-              var statusColor = 'green';
+              // Palette from https://github.com/expressjs/morgan/blob/master/index.js#L201
+              var statusColor = 'reset';
               if (res.statusCode >= 500) statusColor = 'red';
               else if (res.statusCode >= 400) statusColor = 'yellow';
               else if (res.statusCode >= 300) statusColor = 'cyan';
+              else if (res.statusCode >= 200) statusColor = 'green';
 
-              expressMsgFormat = chalk.grey("{{req.method}} {{req.url}}") +
-                " {{res.statusCode}} " +
-                chalk.grey("{{res.responseTime}}ms");
+              expressMsgFormat = chalk.reset(expressMsgFormat)
+
               coloredRes.statusCode = chalk[statusColor](res.statusCode);
             }
             var msgFormat = !options.expressFormat ? options.msg : expressMsgFormat;

--- a/test/test.js
+++ b/test/test.js
@@ -691,8 +691,8 @@ describe('express-winston', function () {
         };
         return loggerTestHelper(testHelperOptions).then(function (result) {
           var resultMsg = result.log.msg;
-          resultMsg.should.startWith('\u001b[90mGET /all-the-things\u001b[39m \u001b[32m200\u001b[39m \u001b[90m');
-          resultMsg.should.endWith('ms\u001b[39m');
+          resultMsg.should.startWith('\x1b[0mGET /all-the-things \x1b[32m200\u001b[39m 0ms\x1b[0m');
+          resultMsg.should.endWith('ms\x1b[0m');
         });
       });
 


### PR DESCRIPTION
Morgan only colors the status code in the log message:
https://github.com/expressjs/morgan/blob/master/index.js#L201 According
to the documentation of colorize the output should match that of morgan.